### PR TITLE
User specific like button

### DIFF
--- a/api/yak.json
+++ b/api/yak.json
@@ -85,14 +85,19 @@
       "id": 9
     },
     {
-      "message": "r2vwgrvgr",
+      "message": "Choopin broccoli",
       "userId": "1",
       "id": 10
     },
     {
-      "message": "Choopin broccoli",
-      "userId": "1",
+      "message": "Joe can beat Steve when it comes to tabletop games!",
+      "userId": "2",
       "id": 11
+    },
+    {
+      "message": "Still working?",
+      "userId": "2",
+      "id": 12
     }
   ],
   "events": [],

--- a/src/ads/Ad.js
+++ b/src/ads/Ad.js
@@ -7,8 +7,9 @@ export default class Ad extends Component {
     render() {
         return (
             <div className="ad">
-                <h5>{this.props.ad.company}</h5>
-                <p>{this.props.ad.message}</p>
+                <h5>{this.props.ad.title}</h5>
+                <p>{this.props.ad.content}</p>
+                <p> - {this.props.ad.company}</p>
             </div>
         )
     }

--- a/src/newsfeed/Post.js
+++ b/src/newsfeed/Post.js
@@ -18,7 +18,7 @@ export default class Post extends Component {
         return (
             <div className="card post">
                 <div className="card-body">
-                    <h5 className="card-title">By {this.props.post.user.email}</h5>
+                    <h5 className="card-title">By {this.props.post.user.fName} {this.props.post.user.lName}</h5>
                     <p className="card-text">
                         {this.props.post.message}
                     </p>

--- a/src/newsfeed/Post.js
+++ b/src/newsfeed/Post.js
@@ -1,12 +1,19 @@
 import React, { Component } from "react"
 import "./Post.css"
 
+
 /**
  * TODOs:
  *     - Only show the Like button if it's another user's post
  *     - Instead of user email, show user's first and last name
  */
+
 export default class Post extends Component {
+    HandleLikeButton = function(param) {
+        if (parseInt(this.props.activeUser) !== parseInt(param)) {
+            return <a href="#" className="btn btn-outline-success">Like</a> 
+        }
+    }
     render() {
         return (
             <div className="card post">
@@ -15,7 +22,8 @@ export default class Post extends Component {
                     <p className="card-text">
                         {this.props.post.message}
                     </p>
-                    <a href="#" className="btn btn-outline-success">Like</a>
+                    {this.HandleLikeButton(this.props.post.user.id)}
+                    {/* <a href="#" className="btn btn-outline-success">Like</a> */}
                 </div>
             </div>
         )

--- a/src/newsfeed/PostList.js
+++ b/src/newsfeed/PostList.js
@@ -9,7 +9,7 @@ export default class PostList extends Component {
             <div className="postList">
                 <h1 className="postList__header">Stories</h1>
                 {
-                    this.props.posts.map(p => <Post key={p.id} post={p} />)
+                    this.props.posts.map(p => <Post activeUser={this.props.activeUser} key={p.id} post={p} />)
                 }
             </div>
         )


### PR DESCRIPTION
Can only like on another users post. Changed some ad formatting to match old DB formatting on ads. 
 ```
git fetch --all
git checkout userSpecific
```

1. Load old YakDB.json from past group Yak in port 5001, pre-boilerplate
1. Sign in, and make a post
1. Should not have a like button available on your post or any of your past posts
1. If there is another post from a different user, there should be a like button available on their post
1. If there is not a comparison post, log out, and log in as someone different
1. Make another post as the new user
1. Should see the post you made as the pervious user NOW with a like button 
1. The post you made as the current user should not contain a like button
<em><strong> Must log in with someone already in database, otherwise will not be able to read a name because it was not created in register</strong> </em> <--- The latest commit feature posts a name instead of an email.